### PR TITLE
Adding a "multiple=true" for list

### DIFF
--- a/admin/models/fields/phocagallerycategory.php
+++ b/admin/models/fields/phocagallerycategory.php
@@ -53,7 +53,7 @@ class JFormFieldPhocaGalleryCategory extends FormField
 		$attr .= $this->element['onchange'] ? ' onchange="'.(string) $this->element['onchange'].'"' : '';
 		$attr .= $this->required ? ' required aria-required="true"' : '';
 		$attr .= ' class="form-select"';
-
+		($this->element->attributes()['multiple'] == true) ? $attr .= ' multiple="multiple"' : '';
 
 		$document					= Factory::getDocument();
 		$document->addCustomTag('<script type="text/javascript">


### PR DESCRIPTION
When adding the Multiple=true attribute for the phocagallery category field, this attribute was not set for the select-option list. Added.